### PR TITLE
Add creates option to unarchive task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
   unarchive: src=/usr/local/src/pgweb_{{ pgweb_version }}_{{ pgweb_os }}_{{ pgweb_arch }}.zip
              dest=/usr/local/bin
              copy=no
+             creates=/usr/local/bin/pgweb
 
 - name: Rename pgweb executable
   command: "mv /usr/local/bin/pgweb_{{ pgweb_os }}_{{ pgweb_arch }} /usr/local/bin/pgweb"


### PR DESCRIPTION
This changeset adds a `creates` option to the `unarchive` task so that it doesn't try to unarchive the ZIP file if the `pgweb` binary already exists.
