### PR TITLE
Switch example from roles.txt to roles.yml

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 if [ "up", "provision" ].include?(ARGV.first) &&
   !(File.directory?("roles/azavea.unzip") || File.symlink?("roles/azavea.unzip"))
 
-  unless system("ansible-galaxy install --force -r roles.txt -p roles")
+  unless system("ansible-galaxy install --force -r roles.yml -p roles")
     $stderr.puts "\nERROR: Please install Ansible 1.4.2+ so that the ansible-galaxy binary"
     $stderr.puts "is available."
     exit(1)

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,0 @@
-azavea.unzip,0.1.0

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,2 @@
+- src: azavea.unzip
+  version: 0.1.0


### PR DESCRIPTION
The CSV format is deprecated as of Ansible 2.0.

##### Testing

Destroy and recreate the example VM after deleting any previously downloaded roles.

```bash
$ cd examples
$ rm -rf roles/azavea.unzip
$ vagrant destroy -f && vagrant up