### PR TITLE
Allow upgrading pgweb to new versions.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-pgweb_version: "0.4.0"
+pgweb_version: "0.9.2"
 pgweb_os: "linux"
 pgweb_arch: "amd64"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,9 +8,17 @@
   unarchive: src=/usr/local/src/pgweb_{{ pgweb_version }}_{{ pgweb_os }}_{{ pgweb_arch }}.zip
              dest=/usr/local/bin
              copy=no
-             creates=/usr/local/bin/pgweb
+             creates=/usr/local/bin/pgweb_{{ pgweb_version }}_{{ pgweb_os }}_{{ pgweb_arch }}
 
 - name: Rename pgweb executable
-  command: "mv /usr/local/bin/pgweb_{{ pgweb_os }}_{{ pgweb_arch }} /usr/local/bin/pgweb"
+  command: "mv /usr/local/bin/pgweb_{{ pgweb_os }}_{{ pgweb_arch }} /usr/local/bin/pgweb_{{ pgweb_version }}_{{ pgweb_os }}_{{ pgweb_arch }}"
   args:
-    creates: "/usr/local/bin/pgweb"
+    creates: "/usr/local/bin/pgweb_{{ pgweb_version }}_{{ pgweb_os }}_{{ pgweb_arch }}"
+
+# force=yes is needed because previous versions deployed a file, not a link
+- name: Symlink pgweb executable to current version
+  file: >
+    src=/usr/local/bin/pgweb_{{ pgweb_version }}_{{ pgweb_os }}_{{ pgweb_arch }}
+    dest=/usr/local/bin/pgweb
+    state=link
+    force=yes


### PR DESCRIPTION
Previously changes to `pgweb_version` on an already provisioned machine would have no affect when reprovisioning, because the `pgweb` executable was already present.

With this change, playbooks using this role should be able to update `pgweb_version` and have that change reflected after rerunning the playbook.
